### PR TITLE
Fix commandline interface

### DIFF
--- a/src/client/lib/appmarket_client.rb
+++ b/src/client/lib/appmarket_client.rb
@@ -16,6 +16,7 @@
 
 require 'uri'
 require 'net/https'
+require 'one_helper'
 
 require 'appmarket_version'
 


### PR DESCRIPTION
Without this module commands `appmarket` and `appmarket-user` are not working:

```
$ appmarket
Traceback (most recent call last):
        2: from /usr/bin/appmarket:101:in `<main>'
        1: from /usr/bin/appmarket:101:in `new'
/usr/lib/one/ruby/cli/command_parser.rb:76:in `initialize': uninitialized constant CommandParser::CmdParser::OpenNebulaHelper (NameError)
```

```
$ appmarket-user 
Traceback (most recent call last):
        2: from /usr/bin/appmarket-user:97:in `<main>'
        1: from /usr/bin/appmarket-user:97:in `new'
/usr/lib/one/ruby/cli/command_parser.rb:76:in `initialize': uninitialized constant CommandParser::CmdParser::OpenNebulaHelper (NameError)
```